### PR TITLE
implements smart delete for pairees

### DIFF
--- a/src/components/Pairees/PaireeDeleteModal.tsx
+++ b/src/components/Pairees/PaireeDeleteModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
@@ -6,6 +6,7 @@ import DialogContent from '@mui/material/DialogContent'
 import DialogContentText from '@mui/material/DialogContentText'
 import DialogTitle from '@mui/material/DialogTitle'
 import { Pairee } from '../../models/interface'
+import { usePairminatorContext } from '../../context/PairminatorContext'
 
 type Props = {
     open: boolean
@@ -18,6 +19,21 @@ export const PaireeDeleteModal = ({
     pairee,
     handleClose
 }: Props): JSX.Element => {
+    const { canHardDeletePairee } = usePairminatorContext()
+    const [canHardDelete, setCanHardDelete] = useState<boolean>(false)
+
+    const checkIfCanDelete = async () => {
+        const result = await canHardDeletePairee(pairee.id)
+        setCanHardDelete(result)
+    }
+
+    useEffect(() => {
+        if (open) {
+            checkIfCanDelete()
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open, setCanHardDelete])
+
     return (
         <Dialog open={open} onClose={() => handleClose()}>
             <DialogTitle>Confirmation</DialogTitle>
@@ -25,6 +41,11 @@ export const PaireeDeleteModal = ({
                 <DialogContentText>
                     Remove <b>{pairee.name}</b> from pairees?
                 </DialogContentText>
+                {!canHardDelete && (
+                    <DialogContentText>
+                        Their pairing history will be maintained.
+                    </DialogContentText>
+                )}
             </DialogContent>
             <DialogActions>
                 <Button

--- a/src/components/Pairees/Pairees.tsx
+++ b/src/components/Pairees/Pairees.tsx
@@ -20,9 +20,11 @@ import { Theme } from '@mui/material'
 import Snackbar from '@mui/material/Snackbar'
 import Alert from '@mui/material/Alert'
 import LoadingButton from '@mui/lab/LoadingButton'
+import { PairingState } from '../../models/enum'
+import Tooltip from '@mui/material/Tooltip'
 
 export const Pairees = (): JSX.Element => {
-    const { activePairees, addPairee, deletePairee } = usePairminatorContext()
+    const { activePairees, project, addPairee, deletePairee } = usePairminatorContext()
     const [newPaireeName, setNewPaireeName] = useState<string>('')
     const [newPaireeError, setNewPaireeError] = useState<boolean>(false)
     const [addingPairee, setAddingPairee] = useState<boolean>(false)
@@ -72,9 +74,23 @@ export const Pairees = (): JSX.Element => {
                             <IconButton onClick={() => setEditing(true)}>
                                 <EditIcon />
                             </IconButton>
-                            <IconButton aria-label="delete" onClick={() => setDeleting(true)}>
-                                <DeleteIcon />
-                            </IconButton>
+                            <Tooltip
+                                title={project?.pairingStatus === PairingState.ASSIGNED
+                                    ? 'Record or Reset pairs to enable deleting pairees'
+                                    : ''
+                                }
+                            >
+                                <IconButton
+                                    aria-label="delete"
+                                    onClick={() => {
+                                        if (project?.pairingStatus !== PairingState.ASSIGNED) {
+                                            setDeleting(true)
+                                        }
+                                    }}
+                                    >
+                                    <DeleteIcon />
+                                </IconButton>
+                            </Tooltip>
                         </>
                         : null
                     }

--- a/src/components/Pairees/Pairees.tsx
+++ b/src/components/Pairees/Pairees.tsx
@@ -97,7 +97,10 @@ export const Pairees = (): JSX.Element => {
                 <PaireeDeleteModal
                     open={deleting}
                     pairee={pairee}
-                    handleClose={handleCloseDeleteModal}
+                    handleClose={(id) => {
+                        handleCloseDeleteModal(id)
+                        setDeleting(false)
+                    }}
                 />
             </>
         )

--- a/src/context/DatabaseContext.tsx
+++ b/src/context/DatabaseContext.tsx
@@ -14,6 +14,7 @@ interface DatabaseContextT {
     handleAddPairee: (projectId: string, name: string) => Promise<boolean>
     handleUpdatePairee: (projectId: string, pairee: Pairee) => Promise<boolean>
     handleDeactivatePairee: (projectId: string, paireeId: string) => Promise<boolean>
+    handleDeletePairee: (projectId: string, paireeId: string) => Promise<boolean>
     handleUpdateLanes: (projectId: string, lanesNeeded: number) => Promise<boolean>
     handleSetCurrentPairs: (projectId: string, pairs: Pair[] | null) => Promise<boolean>
     handleRecordPairs: (projectId: string, currentPairs: Pair[]) => Promise<boolean>
@@ -97,6 +98,21 @@ export const DatabaseProvider: React.FC<ProviderProps> = ({ children }) => {
             return false
         } catch (e) {
             console.error('Error deactivate pairee:', e)
+            return false
+        }
+    }
+
+    const handleDeletePairee = async (projectId: string, paireeId: string): Promise<boolean> => {
+        try {
+            const paireeDoc = await getDoc(doc(database, COLLECTION_PROJECTS, projectId, COLLECTION_PAIREES, paireeId).withConverter(paireeConverter))
+            const pairee = paireeDoc.data()
+            if (pairee) {
+                await deleteDoc(paireeDoc.ref)
+                return true
+            }
+            return false
+        } catch (e) {
+            console.error('Error deleting pairee:', e)
             return false
         }
     }
@@ -190,6 +206,7 @@ export const DatabaseProvider: React.FC<ProviderProps> = ({ children }) => {
         handleAddPairee,
         handleUpdatePairee,
         handleDeactivatePairee,
+        handleDeletePairee,
         handleUpdateLanes,
         handleSetCurrentPairs,
         handleRecordPairs,


### PR DESCRIPTION
#14 

- Adds an additional message on the pairee delete modal if the person exists in the pairing history.
- Actually deletes pairees now if they haven't been included in any pairing assignments.
- Disables deletion ability when current pairs are assigned but not recorded.